### PR TITLE
Tackle comments from finding documents and bump up coverage across the board

### DIFF
--- a/contracts/governance/TimeController.sol
+++ b/contracts/governance/TimeController.sol
@@ -61,6 +61,7 @@ contract TimelockController is AccessControl {
 
     /**
      * @dev Emitted when a call is scheduled as part of operation `id`.
+     * NOTE: includes `description` to be able to fill-up UI with event emitted
      */
     event CallScheduled(
         bytes32 indexed id,
@@ -71,11 +72,13 @@ contract TimelockController is AccessControl {
         bytes32 predecessor,
         uint256 readyTime,
         address sender,
+        string description,
         string status
     );
 
     /**
      * @dev Emitted when a call is performed as part of operation `id`.
+     * NOTE: does not emit `description` as it is not argument needed for executing
      */
     event CallExecuted(
         bytes32 indexed id,
@@ -306,11 +309,11 @@ contract TimelockController is AccessControl {
     function schedule(
         address target,
         uint256 value,
-        // string calldata signature,
         bytes calldata data,
         bytes32 predecessor,
         bytes32 salt,
-        uint256 delay
+        uint256 delay,
+        string memory description
     ) public virtual onlyRole(PROPOSER_ROLE) {
         bytes32 id = hashOperation(target, value, data, predecessor, salt);
         _schedule(id, delay);
@@ -323,6 +326,7 @@ contract TimelockController is AccessControl {
             predecessor,
             getTimestamp(id),
             msg.sender,
+            description,
             "Proposed"
         );
     }
@@ -340,10 +344,10 @@ contract TimelockController is AccessControl {
         address[] calldata targets,
         uint256[] calldata values,
         bytes[] calldata datas,
-        // string[] calldata signatures,
         bytes32 predecessor,
         bytes32 salt,
-        uint256 delay
+        uint256 delay,
+        string memory description
     ) public virtual onlyRole(PROPOSER_ROLE) {
         require(
             targets.length == values.length,
@@ -372,6 +376,7 @@ contract TimelockController is AccessControl {
                 predecessor,
                 getTimestamp(id),
                 msg.sender,
+                description,
                 "Proposed"
             );
         }

--- a/contracts/governance/TimeController.sol
+++ b/contracts/governance/TimeController.sol
@@ -30,11 +30,16 @@ contract TimelockController is AccessControl {
         REJECTED
     }
 
+    /// @dev supreme ruling enum tells if a disputed operation is vetoed or reject
+    /// 0 => accept veto, then cancelling completly the operation and removing from mapping
+    /// 1 => reject the vetoed action and it can be executed normally after the delay
     enum SupremeRuling {
         ACCEPT_VETO,
         REJECT_VETO
     }
 
+    /// @dev used to hold timestamp of when tx can be executed or if completed `_DONE_TIMESTAMP`
+    /// and proposed tx state regarding if it is has being disputed, rejected or not-disputed
     struct TxInfo {
         uint128 timestamp;
         DisputeState state;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,17 +2,41 @@ from brownie import accounts, TimelockController
 from dotmap import DotMap
 import pytest
 
+
+@pytest.fixture
+def deployer():
+    return accounts[0]
+
+
+@pytest.fixture
+def proposer():
+    return accounts[1]
+
+
+@pytest.fixture
+def executor():
+    return accounts[2]
+
+
+@pytest.fixture
+def veto():
+    return accounts[3]
+
+
+@pytest.fixture
+def supremecourt():
+    return accounts[4]
+
+
+@pytest.fixture
+def cancellor():
+    return accounts[5]
+
+
 # fixture to deploy TimeController contract
 @pytest.fixture()
-def deploy():
-    deployer = accounts[0]
-    proposer = accounts[1]
-    executor = accounts[2]
-    veto = accounts[3]
-    supremecourt = accounts[4]
-    cancellor = accounts[5]
-
-    deployedTC = TimelockController.deploy(
+def timelock(deployer, proposer, executor, veto, supremecourt, cancellor):
+    timelock = TimelockController.deploy(
         0,
         [proposer],
         [executor],
@@ -21,15 +45,8 @@ def deploy():
         [cancellor],
         {"from": deployer},
     )
-    return DotMap(
-        contract=deployedTC,
-        deployer=deployer,
-        proposer=proposer,
-        executor=executor,
-        veto=veto,
-        supremecourt=supremecourt,
-        cancellor=cancellor,
-    )
+
+    return timelock
 
 
 # fixture to create a dummy operation so that we can test callDispute on this operation
@@ -46,10 +63,33 @@ def random_operation():
     )
 
 
+@pytest.fixture()
+def random_second_operation():
+    return DotMap(
+        target=accounts[7],
+        value=0,
+        data="0x0e5c011e",
+        predecessor=0,
+        salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
+        delay=0,
+    )
+
+
+@pytest.fixture()
+def random_broken_operation():
+    return DotMap(
+        target="0x647eeb5C5ED5A71621183f09F6CE8fa66b96827d",
+        value=0,
+        data="0x0e5c011e",
+        predecessor=0,
+        salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
+        delay=0,
+    )
+
+
 # fixture to schedule an operation
 @pytest.fixture()
-def schedule_operation(deploy, random_operation):
-    contract = deploy.contract
+def schedule_operation(timelock, random_operation, proposer):
     # schedule a proposal
     target = random_operation.target
     value = random_operation.value
@@ -57,17 +97,14 @@ def schedule_operation(deploy, random_operation):
     predecessor = random_operation.predecessor
     salt = random_operation.salt
     delay = random_operation.delay
-    contract.schedule(
-        target, value, data, predecessor, salt, delay, {"from": deploy.proposer}
-    )
-    id = contract.hashOperation(target, value, data, predecessor, salt)
+    timelock.schedule(target, value, data, predecessor, salt, delay, {"from": proposer})
+    id = timelock.hashOperation(target, value, data, predecessor, salt)
     return id
 
 
 # fixture to dispute an operation
 @pytest.fixture()
-def dispute_operation(deploy, schedule_operation):
+def dispute_operation(timelock, schedule_operation, veto):
     id = schedule_operation
-    contract = deploy.contract
-    contract.callDispute(id, {"from": deploy.veto})
+    timelock.callDispute(id, {"from": veto})
     return id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def random_operation():
         predecessor=0,
         salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
         delay=0,
+        description="# Proposal ## Investment",
     )
 
 
@@ -72,6 +73,7 @@ def random_second_operation():
         predecessor=0,
         salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
         delay=0,
+        description="# Proposal ## Fees Update",
     )
 
 
@@ -84,6 +86,7 @@ def random_broken_operation():
         predecessor=0,
         salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
         delay=0,
+        description="# Proposal ## Emissions Update",
     )
 
 
@@ -97,7 +100,10 @@ def schedule_operation(timelock, random_operation, proposer):
     predecessor = random_operation.predecessor
     salt = random_operation.salt
     delay = random_operation.delay
-    timelock.schedule(target, value, data, predecessor, salt, delay, {"from": proposer})
+    description = random_operation.description
+    timelock.schedule(
+        target, value, data, predecessor, salt, delay, description, {"from": proposer}
+    )
     id = timelock.hashOperation(target, value, data, predecessor, salt)
     return id
 

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -1,0 +1,55 @@
+from brownie import reverts
+
+
+def test_grant_role_no_auth(timelock, accounts):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+    TIMELOCK_ADMIN_ROLE = timelock.TIMELOCK_ADMIN_ROLE()
+
+    revert_msg = f"AccessControl: account {accounts[8].address.lower()} is missing role {TIMELOCK_ADMIN_ROLE}"
+    with reverts(revert_msg):
+        timelock.grantRole(EXECUTOR_ROLE, accounts[7], {"from": accounts[8]})
+
+
+def test_gran_role_admin(timelock, accounts):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    tx = timelock.grantRole(EXECUTOR_ROLE, accounts[6], {"from": timelock})
+
+    granted_role_event = tx.events["RoleGranted"]
+    assert len(granted_role_event) > 0
+    assert (
+        granted_role_event["role"] == EXECUTOR_ROLE
+        and granted_role_event["account"] == accounts[6]
+    )
+
+    assert timelock.hasRole(EXECUTOR_ROLE, accounts[6])
+
+
+def test_revoke_role_assigned(timelock, executor):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    tx = timelock.revokeRole(EXECUTOR_ROLE, executor, {"from": timelock})
+
+    role_revoked_event = tx.events["RoleRevoked"]
+    assert len(role_revoked_event) > 0
+    assert (
+        role_revoked_event["role"] == EXECUTOR_ROLE
+        and role_revoked_event["account"] == executor
+    )
+
+    assert timelock.hasRole(EXECUTOR_ROLE, executor) == False
+
+
+def test_renounce_role_no_auth(timelock, executor, accounts):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    with reverts("AccessControl: can only renounce roles for self"):
+        timelock.renounceRole(EXECUTOR_ROLE, executor, {"from": accounts[5]})
+
+
+def test_renounce_role_for_self(timelock, executor):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    timelock.renounceRole(EXECUTOR_ROLE, executor, {"from": executor})
+
+    assert timelock.hasRole(EXECUTOR_ROLE, executor) == False

--- a/tests/test_after_call_disputed.py
+++ b/tests/test_after_call_disputed.py
@@ -1,40 +1,37 @@
-import pytest
-import brownie
+from brownie import reverts
 
 
 # test - an operation can not be executed if it is disputed
-def test_execute(deploy, dispute_operation, random_operation):
-    id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
+def test_execute(timelock, executor, dispute_operation, random_operation):
+
     # transaction should revert as it is disputed
-    with brownie.reverts(
-        "TimelockController: operation is disputed so it can not be executed"
-    ):
-        contract.execute(
+    with reverts("TimelockController: operation is disputed so it can not be executed"):
+        timelock.execute(
             random_operation.target,
             random_operation.value,
             random_operation.data,
             random_operation.predecessor,
             random_operation.salt,
-            {"from": deploy.executor},
+            {"from": executor},
         )
 
 
 # test- if a supreme court decision is true, the operation should be cancelled once veto is passed
-def test_veto_passed(deploy, dispute_operation):
+def test_veto_passed(timelock, supremecourt, dispute_operation):
     id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
-    contract.callDisputeResolve(id, True, "", {"from": deploy.supremecourt})
+
+    ACCEPT_VETO = 0
+    timelock.callDisputeResolve(id, ACCEPT_VETO, "", {"from": supremecourt})
+
     # Operation should be cancelled
-    assert contract.isOperation(id) == False
+    assert timelock.isOperation(id) == False
 
 
 # test- if a supreme court decision is false, it should not be disputed after callDisputeResolve
-def test_veto_failed(deploy, dispute_operation):
+def test_veto_failed(timelock, supremecourt, dispute_operation):
     id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
-    contract.callDisputeResolve(id, False, "", {"from": deploy.supremecourt})
-    assert contract.getDisputeStatus(id) == 2
+
+    REJECT_VETO = 1
+    timelock.callDisputeResolve(id, REJECT_VETO, "", {"from": supremecourt})
+
+    assert timelock.getDisputeStatus(id) == 2

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -1,0 +1,270 @@
+from brownie import chain, reverts
+
+
+def test_batch_schedule_no_auth(timelock, random_operation, accounts):
+    PROPOSER_ROLE = timelock.PROPOSER_ROLE()
+
+    revert_msg = f"AccessControl: account {accounts[8].address.lower()} is missing role {PROPOSER_ROLE}"
+    with reverts(revert_msg):
+        timelock.scheduleBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            random_operation.delay,
+            {"from": accounts[8]},
+        )
+
+
+def test_batch_schedule_min_delay(timelock, random_operation, proposer):
+    NEW_DELAY = 5000
+    timelock.updateDelay(NEW_DELAY, {"from": timelock})
+
+    with reverts("TimelockController: insufficient delay"):
+        timelock.scheduleBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            NEW_DELAY - 500,
+            {"from": proposer},
+        )
+
+
+def test_batch_schedule_mismatch_length(timelock, random_operation, proposer):
+    # diff target lenght != value
+    with reverts("TimelockController: length mismatch"):
+        timelock.scheduleBatch(
+            [random_operation.target, random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            0,
+            {"from": proposer},
+        )
+
+    # diff target lenght != data
+    with reverts("TimelockController: length mismatch"):
+        timelock.scheduleBatch(
+            [random_operation.target, random_operation.target],
+            [random_operation.value, random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            0,
+            {"from": proposer},
+        )
+
+
+def test_batch_schedule_same_operation(timelock, random_operation, proposer):
+    timelock.scheduleBatch(
+        [random_operation.target],
+        [random_operation.value],
+        [random_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        {"from": proposer},
+    )
+
+    with reverts("TimelockController: operation already scheduled"):
+        timelock.scheduleBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            0,
+            {"from": proposer},
+        )
+
+
+def test_batch_schedule(timelock, random_operation, random_second_operation, proposer):
+    tx = timelock.scheduleBatch(
+        [random_operation.target, random_second_operation.target],
+        [random_operation.value, random_second_operation.value],
+        [random_operation.data, random_second_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        {"from": proposer},
+    )
+
+    block_timestamp = chain[tx.block_number].timestamp
+    schedule_events = tx.events["CallScheduled"]
+    # queue 2 targets/actions
+    assert len(schedule_events) > 1
+
+    for event in schedule_events:
+        id = event["id"]
+        assert timelock.getTimestamp(id) == block_timestamp
+
+
+def test_batch_execution_no_schedule(timelock, random_operation, executor):
+    with reverts("TimelockController: operation is not ready"):
+        timelock.executeBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": executor},
+        )
+
+
+def test_batch_execution_early(timelock, random_operation, proposer, executor):
+    NEW_DELAY = 5000
+    timelock.updateDelay(NEW_DELAY, {"from": timelock})
+
+    tx = timelock.scheduleBatch(
+        [random_operation.target],
+        [random_operation.value],
+        [random_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        NEW_DELAY,
+        {"from": proposer},
+    )
+
+    block_timestamp = chain[tx.block_number].timestamp
+    chain.mine(timestamp=block_timestamp + (NEW_DELAY / 2))
+
+    with reverts("TimelockController: operation is not ready"):
+        timelock.executeBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": executor},
+        )
+
+    # mining further to test exec
+    chain.mine(timestamp=block_timestamp + NEW_DELAY)
+
+    timelock.executeBatch(
+        [random_operation.target],
+        [random_operation.value],
+        [random_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        {"from": executor},
+    )
+
+
+def test_batch_execution_no_auth(timelock, random_operation, proposer, accounts):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    timelock.scheduleBatch(
+        [random_operation.target],
+        [random_operation.value],
+        [random_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        {"from": proposer},
+    )
+
+    revert_msg = f"AccessControl: account {accounts[8].address.lower()} is missing role {EXECUTOR_ROLE}"
+    with reverts(revert_msg):
+        timelock.executeBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": accounts[8]},
+        )
+
+
+def test_batch_execution_mismatch_length(
+    timelock, random_operation, random_second_operation, proposer, executor
+):
+    timelock.scheduleBatch(
+        [random_operation.target, random_second_operation.target],
+        [random_operation.value, random_second_operation.value],
+        [random_operation.data, random_second_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        {"from": proposer},
+    )
+
+    # diff target lenght != value
+    with reverts("TimelockController: length mismatch"):
+        timelock.executeBatch(
+            [random_operation.target, random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": executor},
+        )
+
+    # diff target lenght != data
+    with reverts("TimelockController: length mismatch"):
+        timelock.executeBatch(
+            [random_operation.target, random_operation.target],
+            [random_operation.value, random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": executor},
+        )
+
+
+def test_batch_execution_tx_revert(
+    timelock, random_broken_operation, proposer, executor
+):
+    timelock.scheduleBatch(
+        [random_broken_operation.target],
+        [random_broken_operation.value],
+        [random_broken_operation.data],
+        random_broken_operation.predecessor,
+        random_broken_operation.salt,
+        0,
+        {"from": proposer},
+    )
+
+    with reverts("TimelockController: underlying transaction reverted"):
+        timelock.executeBatch(
+            [random_broken_operation.target],
+            [random_broken_operation.value],
+            [random_broken_operation.data],
+            random_broken_operation.predecessor,
+            random_broken_operation.salt,
+            {"from": executor},
+        )
+
+
+def test_batch_execution(
+    timelock, random_operation, random_second_operation, proposer, executor
+):
+    timelock.scheduleBatch(
+        [random_operation.target, random_second_operation.target],
+        [random_operation.value, random_second_operation.value],
+        [random_operation.data, random_second_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        {"from": proposer},
+    )
+
+    tx = timelock.executeBatch(
+        [random_operation.target, random_second_operation.target],
+        [random_operation.value, random_second_operation.value],
+        [random_operation.data, random_second_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        {"from": executor},
+    )
+
+    call_executed_events = tx.events["CallExecuted"]
+    assert len(call_executed_events) > 1
+
+    for event in call_executed_events:
+        id = event["id"]
+        assert timelock.getTimestamp(id) == 1

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -13,6 +13,7 @@ def test_batch_schedule_no_auth(timelock, random_operation, accounts):
             random_operation.predecessor,
             random_operation.salt,
             random_operation.delay,
+            random_operation.description,
             {"from": accounts[8]},
         )
 
@@ -29,6 +30,7 @@ def test_batch_schedule_min_delay(timelock, random_operation, proposer):
             random_operation.predecessor,
             random_operation.salt,
             NEW_DELAY - 500,
+            random_operation.description,
             {"from": proposer},
         )
 
@@ -43,6 +45,7 @@ def test_batch_schedule_mismatch_length(timelock, random_operation, proposer):
             random_operation.predecessor,
             random_operation.salt,
             0,
+            random_operation.description,
             {"from": proposer},
         )
 
@@ -55,6 +58,7 @@ def test_batch_schedule_mismatch_length(timelock, random_operation, proposer):
             random_operation.predecessor,
             random_operation.salt,
             0,
+            random_operation.description,
             {"from": proposer},
         )
 
@@ -67,6 +71,7 @@ def test_batch_schedule_same_operation(timelock, random_operation, proposer):
         random_operation.predecessor,
         random_operation.salt,
         0,
+        random_operation.description,
         {"from": proposer},
     )
 
@@ -78,6 +83,7 @@ def test_batch_schedule_same_operation(timelock, random_operation, proposer):
             random_operation.predecessor,
             random_operation.salt,
             0,
+            random_operation.description,
             {"from": proposer},
         )
 
@@ -90,6 +96,7 @@ def test_batch_schedule(timelock, random_operation, random_second_operation, pro
         random_operation.predecessor,
         random_operation.salt,
         0,
+        random_operation.description,
         {"from": proposer},
     )
 
@@ -126,6 +133,7 @@ def test_batch_execution_early(timelock, random_operation, proposer, executor):
         random_operation.predecessor,
         random_operation.salt,
         NEW_DELAY,
+        random_operation.description,
         {"from": proposer},
     )
 
@@ -165,6 +173,7 @@ def test_batch_execution_no_auth(timelock, random_operation, proposer, accounts)
         random_operation.predecessor,
         random_operation.salt,
         0,
+        random_operation.description,
         {"from": proposer},
     )
 
@@ -190,6 +199,7 @@ def test_batch_execution_mismatch_length(
         random_operation.predecessor,
         random_operation.salt,
         0,
+        random_operation.description,
         {"from": proposer},
     )
 
@@ -226,6 +236,7 @@ def test_batch_execution_tx_revert(
         random_broken_operation.predecessor,
         random_broken_operation.salt,
         0,
+        random_broken_operation.description,
         {"from": proposer},
     )
 
@@ -250,6 +261,7 @@ def test_batch_execution(
         random_operation.predecessor,
         random_operation.salt,
         0,
+        random_operation.description,
         {"from": proposer},
     )
 

--- a/tests/test_call_dispute.py
+++ b/tests/test_call_dispute.py
@@ -1,31 +1,34 @@
-from brownie import accounts, TimelockController
-import brownie
-import pytest
+from brownie import reverts
 
 # test only veto can dispute the Operation
-def test_dispute_operation_role(deploy, schedule_operation):
+def test_dispute_operation_role(timelock, schedule_operation, executor):
     id = schedule_operation
-    contract = deploy.contract
     # the transaction should revert as it is not getting called from veto
-    with brownie.reverts():
-        contract.callDispute(id, {"from": deploy.executor})
+    with reverts():
+        timelock.callDispute(id, {"from": executor})
 
 
 # test to check if an operation is disputed after it is Disputed
-def test_dispute_operation_pause(deploy, schedule_operation):
+def test_dispute_operation_pause(timelock, schedule_operation, veto):
     id = schedule_operation
-    contract = deploy.contract
-    contract.callDispute(id, {"from": deploy.veto})
-    assert contract.getDisputeStatus(id) == 1
+    timelock.callDispute(id, {"from": veto})
+    assert timelock.getDisputeStatus(id) == 1
 
 
 # test- an operation is disputed it can not be disputed
-def test_dispute_operation_disputed(deploy, schedule_operation):
+def test_dispute_operation_disputed(timelock, schedule_operation, veto):
     id = schedule_operation
-    contract = deploy.contract
-    contract.callDispute(id, {"from": deploy.veto})
+    timelock.callDispute(id, {"from": veto})
     # transaction should revert as it is already disputed
-    with brownie.reverts(
+    with reverts(
         "TimelockController: operation is either already disputed or can not be disputed"
     ):
-        contract.callDispute(id, {"from": deploy.veto})
+        timelock.callDispute(id, {"from": veto})
+
+
+# test- an operation is disputed when does not exist
+def test_dispute_non_existent_operation(timelock, veto):
+    with reverts(
+        "TimelockController: operation is either done or does not exist, can not be disputed"
+    ):
+        timelock.callDispute("0x", {"from": veto})

--- a/tests/test_cancel_operation.py
+++ b/tests/test_cancel_operation.py
@@ -1,0 +1,26 @@
+from brownie import reverts
+
+
+def test_cancel_operation(timelock, schedule_operation, cancellor):
+    id = schedule_operation
+    tx = timelock.cancel(id, {"from": cancellor})
+
+    cancel_event = tx.events["Cancelled"]
+    assert len(cancel_event) > 0
+    assert cancel_event["id"] == id and cancel_event["sender"] == cancellor
+
+    assert timelock.getTimestamp(id) == 0
+
+
+def test_cancel_invalidad_operation(timelock, cancellor):
+    with reverts("TimelockController: operation cannot be cancelled"):
+        timelock.cancel("0x", {"from": cancellor})
+
+
+def test_cancel_no_auth(timelock, schedule_operation, accounts):
+    id = schedule_operation
+    CANCELLOR_ROLE = timelock.CANCELLOR_ROLE()
+
+    revert_msg = f"AccessControl: account {accounts[7].address.lower()} is missing role {CANCELLOR_ROLE}"
+    with reverts(revert_msg):
+        timelock.cancel(id, {"from": accounts[7]})

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,48 +1,111 @@
-import pytest
-import brownie
+from brownie import reverts
 
-# test to check that operation should execute once supereme court rejects the veto
-def test_execute_after_dispute(deploy, dispute_operation, random_operation):
+
+def test_resolve_dispute_no_auth(
+    timelock, dispute_operation, random_operation, executor, accounts
+):
+    SUPREMECOURT_ROLE = timelock.SUPREMECOURT_ROLE()
     # dispute the operation
     id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
 
-    # received supereme court judgement as false
-    contract.callDisputeResolve(id, False, "", {"from": deploy.supremecourt})
+    # received supereme court judgement as reject
+    SUPREME_COURT_REJECT = 1
+    revert_msg = f"AccessControl: account {accounts[8].address.lower()} is missing role {SUPREMECOURT_ROLE}"
+    with reverts(revert_msg):
+        timelock.callDisputeResolve(id, SUPREME_COURT_REJECT, "", {"from": accounts[8]})
+
+
+def test_resolve_no_disputed(timelock, schedule_operation, supremecourt):
+    id = schedule_operation
+
+    SUPREME_COURT_REJECT = 1
+    with reverts("TimelockController: operation is not disputed"):
+        timelock.callDisputeResolve(
+            id, SUPREME_COURT_REJECT, "", {"from": supremecourt}
+        )
+
+
+# test to check that operation should execute once supereme court rejects the veto
+def test_execute_after_dispute(
+    timelock, dispute_operation, random_operation, executor, supremecourt
+):
+    # dispute the operation
+    id = dispute_operation
+
+    # received supereme court judgement as reject
+    SUPREME_COURT_REJECT = 1
+    timelock.callDisputeResolve(id, SUPREME_COURT_REJECT, "", {"from": supremecourt})
 
     # check the operation should not be disputed now
-    assert contract.getDisputeStatus(id) == 2
+    assert timelock.getDisputeStatus(id) == 2
 
     # execute the operation
-    contract.execute(
+    timelock.execute(
         random_operation.target,
         random_operation.value,
         random_operation.data,
         random_operation.predecessor,
         random_operation.salt,
-        {"from": deploy.executor},
+        {"from": executor},
     )
 
     # check if the operation is done
-    assert contract.isOperationDone(id) == True
+    assert timelock.isOperationDone(id) == True
 
 
 # test to check that operation could not be disputed once veto is failed by supereme court
-def test_pause_after_veto_failed(deploy, dispute_operation, random_operation):
+def test_pause_after_veto_failed(
+    timelock, dispute_operation, random_operation, veto, supremecourt
+):
     # dispute the operation
     id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
 
-    # received supereme court judgement as false
-    contract.callDisputeResolve(id, False, "", {"from": deploy.supremecourt})
-
+    # received supereme court judgement as reject
+    SUPREME_COURT_REJECT = 1
+    timelock.callDisputeResolve(id, SUPREME_COURT_REJECT, "", {"from": supremecourt})
     # check the operation should not be disputed now
-    assert contract.getDisputeStatus(id) == 2
+    assert timelock.getDisputeStatus(id) == 2
 
     # transaction should revert as the once the veto is failed for one operation that operation can not be disputed again
-    with brownie.reverts(
+    with reverts(
         "TimelockController: operation is either already disputed or can not be disputed"
     ):
-        contract.callDispute(id, {"from": deploy.veto})
+        timelock.callDispute(id, {"from": veto})
+
+
+# test the flow of trying to exec a proposed payload without predecessor being exec, needs revert
+def test_execution_with_predecessor(
+    timelock, random_operation, random_second_operation, proposer, executor
+):
+    tx = timelock.schedule(
+        random_operation.target,
+        random_operation.value,
+        random_operation.data,
+        random_operation.predecessor,
+        random_operation.salt,
+        random_operation.delay,
+        {"from": proposer},
+    )
+
+    call_schedule_event = tx.events["CallScheduled"]
+    predecessor_id = call_schedule_event["id"]
+
+    timelock.schedule(
+        random_second_operation.target,
+        random_second_operation.value,
+        random_second_operation.data,
+        predecessor_id,
+        random_second_operation.salt,
+        random_second_operation.delay,
+        {"from": proposer},
+    )
+
+    with reverts("TimelockController: missing dependency"):
+        timelock.execute(
+            random_second_operation.target,
+            random_second_operation.value,
+            random_second_operation.data,
+            predecessor_id,
+            random_second_operation.salt,
+            {"from": executor},
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -84,6 +84,7 @@ def test_execution_with_predecessor(
         random_operation.predecessor,
         random_operation.salt,
         random_operation.delay,
+        random_operation.description,
         {"from": proposer},
     )
 
@@ -97,6 +98,7 @@ def test_execution_with_predecessor(
         predecessor_id,
         random_second_operation.salt,
         random_second_operation.delay,
+        random_second_operation.description,
         {"from": proposer},
     )
 

--- a/tests/test_update_delay.py
+++ b/tests/test_update_delay.py
@@ -1,0 +1,21 @@
+from brownie import reverts
+
+
+def test_update_delay_no_allowed_address(timelock, accounts):
+    with reverts("TimelockController: caller must be timelock"):
+        timelock.updateDelay(8000, {"from": accounts[5]})
+
+
+def test_update_delayed_timelock_trigger(timelock):
+    NEW_DELAY = 10_000
+    old_delay_val = timelock.getMinDelay()
+
+    tx = timelock.updateDelay(NEW_DELAY, {"from": timelock})
+
+    # assert event
+    min_delayed_change_event = tx.events["MinDelayChange"]
+    assert len(min_delayed_change_event) > 0
+    assert min_delayed_change_event["oldDuration"] == old_delay_val
+
+    # assert update value
+    assert timelock.getMinDelay() == NEW_DELAY


### PR DESCRIPTION
Tackles the finding in this [doc](https://github.com/GalloDaSballo/badger_governance_veto/blob/feat-review-alex/Findings.MD)

Coverage has being improved up to 94%

<img width="1328" alt="Screenshot 2022-11-01 at 00 29 51" src="https://user-images.githubusercontent.com/84875062/199080936-1479a652-19ed-4db4-a028-83596a9be7b4.png">

**Note:** also it includes a new argument in **schedule** and **scheduleBatch** methods, which will help for the context of the proposed transaction. It can be leverage later on the governance portal to fill it up the ui, interpreting the markdown in the string. This argument is not passed in the executions, since it is not needed to create the hash.
