### PR TITLE
feat: increase coverage across the board and include enums for readability

### DIFF
--- a/contracts/governance/TimeController.sol
+++ b/contracts/governance/TimeController.sol
@@ -53,10 +53,12 @@ contract TimelockController is AccessControl {
     bytes32 public constant SUPREMECOURT_ROLE = keccak256("SUPREMECOURT_ROLE");
     bytes32 public constant CANCELLOR_ROLE = keccak256("CANCELLOR_ROLE");
 
+    uint256 public constant MINIMUM_DELAY = 2 days;
+    uint256 public constant MAXIMUM_DELAY = 30 days;
+
     uint128 internal constant _DONE_TIMESTAMP = uint128(1);
 
     mapping(bytes32 => TxInfo) private _transactionInfo;
-
     uint256 private _minDelay;
 
     /**
@@ -132,6 +134,15 @@ contract TimelockController is AccessControl {
         address[] memory supremecourts,
         address[] memory cancellors
     ) {
+        require(
+            minDelay >= MINIMUM_DELAY,
+            "TimelockController: delay must exceed minimum delay"
+        );
+        require(
+            minDelay <= MAXIMUM_DELAY,
+            "TimelockController: delay must not exceed maximum delay"
+        );
+
         _setRoleAdmin(TIMELOCK_ADMIN_ROLE, TIMELOCK_ADMIN_ROLE);
         _setRoleAdmin(PROPOSER_ROLE, TIMELOCK_ADMIN_ROLE);
         _setRoleAdmin(EXECUTOR_ROLE, TIMELOCK_ADMIN_ROLE);
@@ -545,6 +556,15 @@ contract TimelockController is AccessControl {
             msg.sender == address(this),
             "TimelockController: caller must be timelock"
         );
+        require(
+            newDelay >= MINIMUM_DELAY,
+            "TimelockController: delay must exceed minimum delay"
+        );
+        require(
+            newDelay <= MAXIMUM_DELAY,
+            "TimelockController: delay must not exceed maximum delay"
+        );
+
         emit MinDelayChange(_minDelay, newDelay);
         _minDelay = newDelay;
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@ from brownie import accounts, TimelockController
 from dotmap import DotMap
 import pytest
 
+# NOTE: min delay is 2 days
+MIN_DELAY = 172_800
+
 
 @pytest.fixture
 def deployer():
@@ -37,7 +40,7 @@ def cancellor():
 @pytest.fixture()
 def timelock(deployer, proposer, executor, veto, supremecourt, cancellor):
     timelock = TimelockController.deploy(
-        0,
+        MIN_DELAY,
         [proposer],
         [executor],
         [veto],
@@ -59,7 +62,7 @@ def random_operation():
         data="0x13e414de",
         predecessor=0,
         salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
-        delay=0,
+        delay=MIN_DELAY,
         description="# Proposal ## Investment",
     )
 
@@ -72,7 +75,7 @@ def random_second_operation():
         data="0x0e5c011e",
         predecessor=0,
         salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
-        delay=0,
+        delay=MIN_DELAY,
         description="# Proposal ## Fees Update",
     )
 
@@ -85,7 +88,7 @@ def random_broken_operation():
         data="0x0e5c011e",
         predecessor=0,
         salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
-        delay=0,
+        delay=MIN_DELAY,
         description="# Proposal ## Emissions Update",
     )
 
@@ -112,5 +115,5 @@ def schedule_operation(timelock, random_operation, proposer):
 @pytest.fixture()
 def dispute_operation(timelock, schedule_operation, veto):
     id = schedule_operation
-    timelock.callDispute(id, {"from": veto})
-    return id
+    tx = timelock.callDispute(id, {"from": veto})
+    return id, tx.block_number

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,17 +2,41 @@ from brownie import accounts, TimelockController
 from dotmap import DotMap
 import pytest
 
+
+@pytest.fixture
+def deployer():
+    return accounts[0]
+
+
+@pytest.fixture
+def proposer():
+    return accounts[1]
+
+
+@pytest.fixture
+def executor():
+    return accounts[2]
+
+
+@pytest.fixture
+def veto():
+    return accounts[3]
+
+
+@pytest.fixture
+def supremecourt():
+    return accounts[4]
+
+
+@pytest.fixture
+def cancellor():
+    return accounts[5]
+
+
 # fixture to deploy TimeController contract
 @pytest.fixture()
-def deploy():
-    deployer = accounts[0]
-    proposer = accounts[1]
-    executor = accounts[2]
-    veto = accounts[3]
-    supremecourt = accounts[4]
-    cancellor = accounts[5]
-
-    deployedTC = TimelockController.deploy(
+def timelock(deployer, proposer, executor, veto, supremecourt, cancellor):
+    timelock = TimelockController.deploy(
         0,
         [proposer],
         [executor],
@@ -21,15 +45,8 @@ def deploy():
         [cancellor],
         {"from": deployer},
     )
-    return DotMap(
-        contract=deployedTC,
-        deployer=deployer,
-        proposer=proposer,
-        executor=executor,
-        veto=veto,
-        supremecourt=supremecourt,
-        cancellor=cancellor,
-    )
+
+    return timelock
 
 
 # fixture to create a dummy operation so that we can test callDispute on this operation
@@ -43,13 +60,39 @@ def random_operation():
         predecessor=0,
         salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
         delay=0,
+        description="# Proposal ## Investment",
+    )
+
+
+@pytest.fixture()
+def random_second_operation():
+    return DotMap(
+        target=accounts[7],
+        value=0,
+        data="0x0e5c011e",
+        predecessor=0,
+        salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
+        delay=0,
+        description="# Proposal ## Fees Update",
+    )
+
+
+@pytest.fixture()
+def random_broken_operation():
+    return DotMap(
+        target="0x647eeb5C5ED5A71621183f09F6CE8fa66b96827d",
+        value=0,
+        data="0x0e5c011e",
+        predecessor=0,
+        salt="0xc1059ed2dc130227aa1d1d539ac94c641306905c020436c636e19e3fab56fc7f",
+        delay=0,
+        description="# Proposal ## Emissions Update",
     )
 
 
 # fixture to schedule an operation
 @pytest.fixture()
-def schedule_operation(deploy, random_operation):
-    contract = deploy.contract
+def schedule_operation(timelock, random_operation, proposer):
     # schedule a proposal
     target = random_operation.target
     value = random_operation.value
@@ -57,17 +100,17 @@ def schedule_operation(deploy, random_operation):
     predecessor = random_operation.predecessor
     salt = random_operation.salt
     delay = random_operation.delay
-    contract.schedule(
-        target, value, data, predecessor, salt, delay, {"from": deploy.proposer}
+    description = random_operation.description
+    timelock.schedule(
+        target, value, data, predecessor, salt, delay, description, {"from": proposer}
     )
-    id = contract.hashOperation(target, value, data, predecessor, salt)
+    id = timelock.hashOperation(target, value, data, predecessor, salt)
     return id
 
 
 # fixture to dispute an operation
 @pytest.fixture()
-def dispute_operation(deploy, schedule_operation):
+def dispute_operation(timelock, schedule_operation, veto):
     id = schedule_operation
-    contract = deploy.contract
-    contract.callDispute(id, {"from": deploy.veto})
+    timelock.callDispute(id, {"from": veto})
     return id

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -1,0 +1,55 @@
+from brownie import reverts
+
+
+def test_grant_role_no_auth(timelock, accounts):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+    TIMELOCK_ADMIN_ROLE = timelock.TIMELOCK_ADMIN_ROLE()
+
+    revert_msg = f"AccessControl: account {accounts[8].address.lower()} is missing role {TIMELOCK_ADMIN_ROLE}"
+    with reverts(revert_msg):
+        timelock.grantRole(EXECUTOR_ROLE, accounts[7], {"from": accounts[8]})
+
+
+def test_gran_role_admin(timelock, accounts):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    tx = timelock.grantRole(EXECUTOR_ROLE, accounts[6], {"from": timelock})
+
+    granted_role_event = tx.events["RoleGranted"]
+    assert len(granted_role_event) > 0
+    assert (
+        granted_role_event["role"] == EXECUTOR_ROLE
+        and granted_role_event["account"] == accounts[6]
+    )
+
+    assert timelock.hasRole(EXECUTOR_ROLE, accounts[6])
+
+
+def test_revoke_role_assigned(timelock, executor):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    tx = timelock.revokeRole(EXECUTOR_ROLE, executor, {"from": timelock})
+
+    role_revoked_event = tx.events["RoleRevoked"]
+    assert len(role_revoked_event) > 0
+    assert (
+        role_revoked_event["role"] == EXECUTOR_ROLE
+        and role_revoked_event["account"] == executor
+    )
+
+    assert timelock.hasRole(EXECUTOR_ROLE, executor) == False
+
+
+def test_renounce_role_no_auth(timelock, executor, accounts):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    with reverts("AccessControl: can only renounce roles for self"):
+        timelock.renounceRole(EXECUTOR_ROLE, executor, {"from": accounts[5]})
+
+
+def test_renounce_role_for_self(timelock, executor):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    timelock.renounceRole(EXECUTOR_ROLE, executor, {"from": executor})
+
+    assert timelock.hasRole(EXECUTOR_ROLE, executor) == False

--- a/tests/test_after_call_disputed.py
+++ b/tests/test_after_call_disputed.py
@@ -1,40 +1,37 @@
-import pytest
-import brownie
+from brownie import reverts
 
 
 # test - an operation can not be executed if it is disputed
-def test_execute(deploy, dispute_operation, random_operation):
-    id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
+def test_execute(timelock, executor, dispute_operation, random_operation):
+
     # transaction should revert as it is disputed
-    with brownie.reverts(
-        "TimelockController: operation is disputed so it can not be executed"
-    ):
-        contract.execute(
+    with reverts("TimelockController: operation is disputed so it can not be executed"):
+        timelock.execute(
             random_operation.target,
             random_operation.value,
             random_operation.data,
             random_operation.predecessor,
             random_operation.salt,
-            {"from": deploy.executor},
+            {"from": executor},
         )
 
 
 # test- if a supreme court decision is true, the operation should be cancelled once veto is passed
-def test_veto_passed(deploy, dispute_operation):
+def test_veto_passed(timelock, supremecourt, dispute_operation):
     id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
-    contract.callDisputeResolve(id, True, "", {"from": deploy.supremecourt})
+
+    ACCEPT_VETO = 0
+    timelock.callDisputeResolve(id, ACCEPT_VETO, "", {"from": supremecourt})
+
     # Operation should be cancelled
-    assert contract.isOperation(id) == False
+    assert timelock.isOperation(id) == False
 
 
 # test- if a supreme court decision is false, it should not be disputed after callDisputeResolve
-def test_veto_failed(deploy, dispute_operation):
+def test_veto_failed(timelock, supremecourt, dispute_operation):
     id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
-    contract.callDisputeResolve(id, False, "", {"from": deploy.supremecourt})
-    assert contract.getDisputeStatus(id) == 2
+
+    REJECT_VETO = 1
+    timelock.callDisputeResolve(id, REJECT_VETO, "", {"from": supremecourt})
+
+    assert timelock.getDisputeStatus(id) == 2

--- a/tests/test_after_call_disputed.py
+++ b/tests/test_after_call_disputed.py
@@ -1,8 +1,12 @@
-from brownie import reverts
+from brownie import reverts, chain
 
 
 # test - an operation can not be executed if it is disputed
 def test_execute(timelock, executor, dispute_operation, random_operation):
+    _, block_number = dispute_operation
+
+    block_timestamp = chain[block_number].timestamp
+    chain.mine(timestamp=block_timestamp + (random_operation.delay * 2))
 
     # transaction should revert as it is disputed
     with reverts("TimelockController: operation is disputed so it can not be executed"):
@@ -18,7 +22,7 @@ def test_execute(timelock, executor, dispute_operation, random_operation):
 
 # test- if a supreme court decision is true, the operation should be cancelled once veto is passed
 def test_veto_passed(timelock, supremecourt, dispute_operation):
-    id = dispute_operation
+    id, _ = dispute_operation
 
     ACCEPT_VETO = 0
     timelock.callDisputeResolve(id, ACCEPT_VETO, "", {"from": supremecourt})
@@ -29,7 +33,7 @@ def test_veto_passed(timelock, supremecourt, dispute_operation):
 
 # test- if a supreme court decision is false, it should not be disputed after callDisputeResolve
 def test_veto_failed(timelock, supremecourt, dispute_operation):
-    id = dispute_operation
+    id, _ = dispute_operation
 
     REJECT_VETO = 1
     timelock.callDisputeResolve(id, REJECT_VETO, "", {"from": supremecourt})

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -1,0 +1,282 @@
+from brownie import chain, reverts
+
+
+def test_batch_schedule_no_auth(timelock, random_operation, accounts):
+    PROPOSER_ROLE = timelock.PROPOSER_ROLE()
+
+    revert_msg = f"AccessControl: account {accounts[8].address.lower()} is missing role {PROPOSER_ROLE}"
+    with reverts(revert_msg):
+        timelock.scheduleBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            random_operation.delay,
+            random_operation.description,
+            {"from": accounts[8]},
+        )
+
+
+def test_batch_schedule_min_delay(timelock, random_operation, proposer):
+    NEW_DELAY = 5000
+    timelock.updateDelay(NEW_DELAY, {"from": timelock})
+
+    with reverts("TimelockController: insufficient delay"):
+        timelock.scheduleBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            NEW_DELAY - 500,
+            random_operation.description,
+            {"from": proposer},
+        )
+
+
+def test_batch_schedule_mismatch_length(timelock, random_operation, proposer):
+    # diff target lenght != value
+    with reverts("TimelockController: length mismatch"):
+        timelock.scheduleBatch(
+            [random_operation.target, random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            0,
+            random_operation.description,
+            {"from": proposer},
+        )
+
+    # diff target lenght != data
+    with reverts("TimelockController: length mismatch"):
+        timelock.scheduleBatch(
+            [random_operation.target, random_operation.target],
+            [random_operation.value, random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            0,
+            random_operation.description,
+            {"from": proposer},
+        )
+
+
+def test_batch_schedule_same_operation(timelock, random_operation, proposer):
+    timelock.scheduleBatch(
+        [random_operation.target],
+        [random_operation.value],
+        [random_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        random_operation.description,
+        {"from": proposer},
+    )
+
+    with reverts("TimelockController: operation already scheduled"):
+        timelock.scheduleBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            0,
+            random_operation.description,
+            {"from": proposer},
+        )
+
+
+def test_batch_schedule(timelock, random_operation, random_second_operation, proposer):
+    tx = timelock.scheduleBatch(
+        [random_operation.target, random_second_operation.target],
+        [random_operation.value, random_second_operation.value],
+        [random_operation.data, random_second_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        random_operation.description,
+        {"from": proposer},
+    )
+
+    block_timestamp = chain[tx.block_number].timestamp
+    schedule_events = tx.events["CallScheduled"]
+    # queue 2 targets/actions
+    assert len(schedule_events) > 1
+
+    for event in schedule_events:
+        id = event["id"]
+        assert timelock.getTimestamp(id) == block_timestamp
+
+
+def test_batch_execution_no_schedule(timelock, random_operation, executor):
+    with reverts("TimelockController: operation is not ready"):
+        timelock.executeBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": executor},
+        )
+
+
+def test_batch_execution_early(timelock, random_operation, proposer, executor):
+    NEW_DELAY = 5000
+    timelock.updateDelay(NEW_DELAY, {"from": timelock})
+
+    tx = timelock.scheduleBatch(
+        [random_operation.target],
+        [random_operation.value],
+        [random_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        NEW_DELAY,
+        random_operation.description,
+        {"from": proposer},
+    )
+
+    block_timestamp = chain[tx.block_number].timestamp
+    chain.mine(timestamp=block_timestamp + (NEW_DELAY / 2))
+
+    with reverts("TimelockController: operation is not ready"):
+        timelock.executeBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": executor},
+        )
+
+    # mining further to test exec
+    chain.mine(timestamp=block_timestamp + NEW_DELAY)
+
+    timelock.executeBatch(
+        [random_operation.target],
+        [random_operation.value],
+        [random_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        {"from": executor},
+    )
+
+
+def test_batch_execution_no_auth(timelock, random_operation, proposer, accounts):
+    EXECUTOR_ROLE = timelock.EXECUTOR_ROLE()
+
+    timelock.scheduleBatch(
+        [random_operation.target],
+        [random_operation.value],
+        [random_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        random_operation.description,
+        {"from": proposer},
+    )
+
+    revert_msg = f"AccessControl: account {accounts[8].address.lower()} is missing role {EXECUTOR_ROLE}"
+    with reverts(revert_msg):
+        timelock.executeBatch(
+            [random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": accounts[8]},
+        )
+
+
+def test_batch_execution_mismatch_length(
+    timelock, random_operation, random_second_operation, proposer, executor
+):
+    timelock.scheduleBatch(
+        [random_operation.target, random_second_operation.target],
+        [random_operation.value, random_second_operation.value],
+        [random_operation.data, random_second_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        random_operation.description,
+        {"from": proposer},
+    )
+
+    # diff target lenght != value
+    with reverts("TimelockController: length mismatch"):
+        timelock.executeBatch(
+            [random_operation.target, random_operation.target],
+            [random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": executor},
+        )
+
+    # diff target lenght != data
+    with reverts("TimelockController: length mismatch"):
+        timelock.executeBatch(
+            [random_operation.target, random_operation.target],
+            [random_operation.value, random_operation.value],
+            [random_operation.data],
+            random_operation.predecessor,
+            random_operation.salt,
+            {"from": executor},
+        )
+
+
+def test_batch_execution_tx_revert(
+    timelock, random_broken_operation, proposer, executor
+):
+    timelock.scheduleBatch(
+        [random_broken_operation.target],
+        [random_broken_operation.value],
+        [random_broken_operation.data],
+        random_broken_operation.predecessor,
+        random_broken_operation.salt,
+        0,
+        random_broken_operation.description,
+        {"from": proposer},
+    )
+
+    with reverts("TimelockController: underlying transaction reverted"):
+        timelock.executeBatch(
+            [random_broken_operation.target],
+            [random_broken_operation.value],
+            [random_broken_operation.data],
+            random_broken_operation.predecessor,
+            random_broken_operation.salt,
+            {"from": executor},
+        )
+
+
+def test_batch_execution(
+    timelock, random_operation, random_second_operation, proposer, executor
+):
+    timelock.scheduleBatch(
+        [random_operation.target, random_second_operation.target],
+        [random_operation.value, random_second_operation.value],
+        [random_operation.data, random_second_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        0,
+        random_operation.description,
+        {"from": proposer},
+    )
+
+    tx = timelock.executeBatch(
+        [random_operation.target, random_second_operation.target],
+        [random_operation.value, random_second_operation.value],
+        [random_operation.data, random_second_operation.data],
+        random_operation.predecessor,
+        random_operation.salt,
+        {"from": executor},
+    )
+
+    call_executed_events = tx.events["CallExecuted"]
+    assert len(call_executed_events) > 1
+
+    for event in call_executed_events:
+        id = event["id"]
+        assert timelock.getTimestamp(id) == 1

--- a/tests/test_call_dispute.py
+++ b/tests/test_call_dispute.py
@@ -1,31 +1,34 @@
-from brownie import accounts, TimelockController
-import brownie
-import pytest
+from brownie import reverts
 
 # test only veto can dispute the Operation
-def test_dispute_operation_role(deploy, schedule_operation):
+def test_dispute_operation_role(timelock, schedule_operation, executor):
     id = schedule_operation
-    contract = deploy.contract
     # the transaction should revert as it is not getting called from veto
-    with brownie.reverts():
-        contract.callDispute(id, {"from": deploy.executor})
+    with reverts():
+        timelock.callDispute(id, {"from": executor})
 
 
 # test to check if an operation is disputed after it is Disputed
-def test_dispute_operation_pause(deploy, schedule_operation):
+def test_dispute_operation_pause(timelock, schedule_operation, veto):
     id = schedule_operation
-    contract = deploy.contract
-    contract.callDispute(id, {"from": deploy.veto})
-    assert contract.getDisputeStatus(id) == 1
+    timelock.callDispute(id, {"from": veto})
+    assert timelock.getDisputeStatus(id) == 1
 
 
 # test- an operation is disputed it can not be disputed
-def test_dispute_operation_disputed(deploy, schedule_operation):
+def test_dispute_operation_disputed(timelock, schedule_operation, veto):
     id = schedule_operation
-    contract = deploy.contract
-    contract.callDispute(id, {"from": deploy.veto})
+    timelock.callDispute(id, {"from": veto})
     # transaction should revert as it is already disputed
-    with brownie.reverts(
+    with reverts(
         "TimelockController: operation is either already disputed or can not be disputed"
     ):
-        contract.callDispute(id, {"from": deploy.veto})
+        timelock.callDispute(id, {"from": veto})
+
+
+# test- an operation is disputed when does not exist
+def test_dispute_non_existent_operation(timelock, veto):
+    with reverts(
+        "TimelockController: operation is either done or does not exist, can not be disputed"
+    ):
+        timelock.callDispute("0x", {"from": veto})

--- a/tests/test_cancel_operation.py
+++ b/tests/test_cancel_operation.py
@@ -1,0 +1,26 @@
+from brownie import reverts
+
+
+def test_cancel_operation(timelock, schedule_operation, cancellor):
+    id = schedule_operation
+    tx = timelock.cancel(id, {"from": cancellor})
+
+    cancel_event = tx.events["Cancelled"]
+    assert len(cancel_event) > 0
+    assert cancel_event["id"] == id and cancel_event["sender"] == cancellor
+
+    assert timelock.getTimestamp(id) == 0
+
+
+def test_cancel_invalidad_operation(timelock, cancellor):
+    with reverts("TimelockController: operation cannot be cancelled"):
+        timelock.cancel("0x", {"from": cancellor})
+
+
+def test_cancel_no_auth(timelock, schedule_operation, accounts):
+    id = schedule_operation
+    CANCELLOR_ROLE = timelock.CANCELLOR_ROLE()
+
+    revert_msg = f"AccessControl: account {accounts[7].address.lower()} is missing role {CANCELLOR_ROLE}"
+    with reverts(revert_msg):
+        timelock.cancel(id, {"from": accounts[7]})

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,48 +1,113 @@
-import pytest
-import brownie
+from brownie import reverts
 
-# test to check that operation should execute once supereme court rejects the veto
-def test_execute_after_dispute(deploy, dispute_operation, random_operation):
+
+def test_resolve_dispute_no_auth(
+    timelock, dispute_operation, random_operation, executor, accounts
+):
+    SUPREMECOURT_ROLE = timelock.SUPREMECOURT_ROLE()
     # dispute the operation
     id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
 
-    # received supereme court judgement as false
-    contract.callDisputeResolve(id, False, "", {"from": deploy.supremecourt})
+    # received supereme court judgement as reject
+    SUPREME_COURT_REJECT = 1
+    revert_msg = f"AccessControl: account {accounts[8].address.lower()} is missing role {SUPREMECOURT_ROLE}"
+    with reverts(revert_msg):
+        timelock.callDisputeResolve(id, SUPREME_COURT_REJECT, "", {"from": accounts[8]})
+
+
+def test_resolve_no_disputed(timelock, schedule_operation, supremecourt):
+    id = schedule_operation
+
+    SUPREME_COURT_REJECT = 1
+    with reverts("TimelockController: operation is not disputed"):
+        timelock.callDisputeResolve(
+            id, SUPREME_COURT_REJECT, "", {"from": supremecourt}
+        )
+
+
+# test to check that operation should execute once supereme court rejects the veto
+def test_execute_after_dispute(
+    timelock, dispute_operation, random_operation, executor, supremecourt
+):
+    # dispute the operation
+    id = dispute_operation
+
+    # received supereme court judgement as reject
+    SUPREME_COURT_REJECT = 1
+    timelock.callDisputeResolve(id, SUPREME_COURT_REJECT, "", {"from": supremecourt})
 
     # check the operation should not be disputed now
-    assert contract.getDisputeStatus(id) == 2
+    assert timelock.getDisputeStatus(id) == 2
 
     # execute the operation
-    contract.execute(
+    timelock.execute(
         random_operation.target,
         random_operation.value,
         random_operation.data,
         random_operation.predecessor,
         random_operation.salt,
-        {"from": deploy.executor},
+        {"from": executor},
     )
 
     # check if the operation is done
-    assert contract.isOperationDone(id) == True
+    assert timelock.isOperationDone(id) == True
 
 
 # test to check that operation could not be disputed once veto is failed by supereme court
-def test_pause_after_veto_failed(deploy, dispute_operation, random_operation):
+def test_pause_after_veto_failed(
+    timelock, dispute_operation, random_operation, veto, supremecourt
+):
     # dispute the operation
     id = dispute_operation
-    deployer = deploy.deployer
-    contract = deploy.contract
 
-    # received supereme court judgement as false
-    contract.callDisputeResolve(id, False, "", {"from": deploy.supremecourt})
-
+    # received supereme court judgement as reject
+    SUPREME_COURT_REJECT = 1
+    timelock.callDisputeResolve(id, SUPREME_COURT_REJECT, "", {"from": supremecourt})
     # check the operation should not be disputed now
-    assert contract.getDisputeStatus(id) == 2
+    assert timelock.getDisputeStatus(id) == 2
 
     # transaction should revert as the once the veto is failed for one operation that operation can not be disputed again
-    with brownie.reverts(
+    with reverts(
         "TimelockController: operation is either already disputed or can not be disputed"
     ):
-        contract.callDispute(id, {"from": deploy.veto})
+        timelock.callDispute(id, {"from": veto})
+
+
+# test the flow of trying to exec a proposed payload without predecessor being exec, needs revert
+def test_execution_with_predecessor(
+    timelock, random_operation, random_second_operation, proposer, executor
+):
+    tx = timelock.schedule(
+        random_operation.target,
+        random_operation.value,
+        random_operation.data,
+        random_operation.predecessor,
+        random_operation.salt,
+        random_operation.delay,
+        random_operation.description,
+        {"from": proposer},
+    )
+
+    call_schedule_event = tx.events["CallScheduled"]
+    predecessor_id = call_schedule_event["id"]
+
+    timelock.schedule(
+        random_second_operation.target,
+        random_second_operation.value,
+        random_second_operation.data,
+        predecessor_id,
+        random_second_operation.salt,
+        random_second_operation.delay,
+        random_second_operation.description,
+        {"from": proposer},
+    )
+
+    with reverts("TimelockController: missing dependency"):
+        timelock.execute(
+            random_second_operation.target,
+            random_second_operation.value,
+            random_second_operation.data,
+            predecessor_id,
+            random_second_operation.salt,
+            {"from": executor},
+        )

--- a/tests/test_update_delay.py
+++ b/tests/test_update_delay.py
@@ -1,0 +1,21 @@
+from brownie import reverts
+
+
+def test_update_delay_no_allowed_address(timelock, accounts):
+    with reverts("TimelockController: caller must be timelock"):
+        timelock.updateDelay(8000, {"from": accounts[5]})
+
+
+def test_update_delayed_timelock_trigger(timelock):
+    NEW_DELAY = 10_000
+    old_delay_val = timelock.getMinDelay()
+
+    tx = timelock.updateDelay(NEW_DELAY, {"from": timelock})
+
+    # assert event
+    min_delayed_change_event = tx.events["MinDelayChange"]
+    assert len(min_delayed_change_event) > 0
+    assert min_delayed_change_event["oldDuration"] == old_delay_val
+
+    # assert update value
+    assert timelock.getMinDelay() == NEW_DELAY

--- a/tests/test_update_delay.py
+++ b/tests/test_update_delay.py
@@ -1,13 +1,26 @@
 from brownie import reverts
 
+MIN_DELAY = 172_800
+MAX_DELAY = 2_592_000
+
 
 def test_update_delay_no_allowed_address(timelock, accounts):
     with reverts("TimelockController: caller must be timelock"):
         timelock.updateDelay(8000, {"from": accounts[5]})
 
 
+def test_update_delay_below_min(timelock):
+    with reverts("TimelockController: delay must exceed minimum delay"):
+        timelock.updateDelay(MIN_DELAY / 2, {"from": timelock})
+
+
+def test_update_delay_above_max(timelock):
+    with reverts("TimelockController: delay must not exceed maximum delay"):
+        timelock.updateDelay(MAX_DELAY * 2, {"from": timelock})
+
+
 def test_update_delayed_timelock_trigger(timelock):
-    NEW_DELAY = 10_000
+    NEW_DELAY = MIN_DELAY * 2
     old_delay_val = timelock.getMinDelay()
 
     tx = timelock.updateDelay(NEW_DELAY, {"from": timelock})


### PR DESCRIPTION
Tackles the finding in this [doc](https://github.com/GalloDaSballo/badger_governance_veto/blob/feat-review-alex/Findings.MD)

Coverage has being improved up to 94%

<img width="1328" alt="Screenshot 2022-11-01 at 00 29 51" src="https://user-images.githubusercontent.com/84875062/199080936-1479a652-19ed-4db4-a028-83596a9be7b4.png">

**Note:** also it includes a new argument in schedule and scheduleBatch methods, which will help for the context of the proposed transaction. It can be leverage later on the governance portal to fill it up the ui, interpreting the markdown in the string. This argument is not passed in the executions, since it is not needed to create the hash.

